### PR TITLE
fix(cobertura): removes rounding

### DIFF
--- a/cobertura/CHANGELOG.md
+++ b/cobertura/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.5
+
+- Removes rounding for source elements
+
 ## 1.0.4
 
 - Removes rounding

--- a/cobertura/bin/src/cobertura.dart
+++ b/cobertura/bin/src/cobertura.dart
@@ -178,10 +178,10 @@ void _writeCobertura({
               var className = path.basenameWithoutExtension(r.file);
 
               var classLineRate = r.lines.found > 0
-                  ? (r.lines.hit / r.lines.found).round()
+                  ? r.lines.hit / r.lines.found
                   : r.lines.found;
               var classBranchRate = r.branches.found > 0
-                  ? (r.branches.hit / r.branches.found).round()
+                  ? r.branches.hit / r.branches.found
                   : r.branches.found;
 
               builder.element("class", attributes: {


### PR DESCRIPTION
The rounding was previously removed one the package level. This commit also removes it for the sources level.
Fixes #6